### PR TITLE
Document saml.username_attribute for the user identifier (Kimai 2.61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Document that the SAML user identifier comes from `kimai.saml.username_attribute`
+  rather than the attribute mapping (required by Kimai 2.61)
+
 ## 1.3.1 - 2025-05-04
 
 - Add missing version number to composer.json

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ If the `Team` have other team leads they are removed to handle situations where 
 ### `App\Entity\User` (User)
 
 - `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress` -> `username`
+  (set by Kimai from `kimai.saml.username_attribute`, not the attribute mapping;
+  a `kimai: username` mapping entry is forbidden as of Kimai 2.61)
 - `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress` -> `email`
 - `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name` -> `alias`
 - `Office` -> `title` (Kimai "title" field renamed in the UI)


### PR DESCRIPTION
Documentation update for the Kimai 2.61 SAML change. No code change.

## Changes

- README: the login user's username / identifier now comes from `kimai.saml.username_attribute` (the emailaddress claim), not the attribute mapping — a `kimai: username` mapping entry is forbidden as of Kimai 2.61.
- CHANGELOG: add an unreleased entry.

## Why

Kimai 2.61 forbids `username` / `userIdentifier` in `kimai.saml.mapping`. The bundle relies on `username == email`, so the guidance moves to `username_attribute` pointed at the email claim. The bundle code is unaffected — it reads `getUsername()` / `getUserIdentifier()`, which Kimai keeps populating.
